### PR TITLE
Add Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+import PackageDescription
+
+let package = Package(
+    name: "OphanThrift",
+    platforms: [
+        .iOS(.v10)
+    ],
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "OphanThrift",
+            targets: ["OphanThrift"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/guardian/thrift-swift.git", .upToNextMinor(from: "0.13.0"))
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "OphanThrift",
+            dependencies: ["Thrift"]),
+        .testTarget(
+            name: "OphanThriftTests",
+            dependencies: ["OphanThrift"]),
+    ]
+)


### PR DESCRIPTION
This should allow the `ios-live` repo to [import this repo/library as a dependency](https://swift.org/package-manager/).

Once this PR and https://github.com/guardian/ophan-thrift-swift/pull/1 have been merged I will add a tag for version `0.1.0`.