### PR TITLE
Remove package.swift reference to tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,8 +22,5 @@ let package = Package(
         .target(
             name: "OphanThrift",
             dependencies: ["Thrift"]),
-        .testTarget(
-            name: "OphanThriftTests",
-            dependencies: ["OphanThrift"]),
     ]
 )


### PR DESCRIPTION
XCode was complaining that the tests weren't in the correct folder.  Since there aren't any tests, we shouldn't include a test target in the swift package