### PR TITLE
Specify Guardian pre-release version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["OphanThrift"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/guardian/thrift-swift.git", .upToNextMinor(from: "0.13.0"))
+        .package(url: "https://github.com/guardian/thrift-swift.git", .exact("0.14.0-gu1"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["OphanThrift"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/guardian/thrift-swift.git", .exact("0.14.0-gu1"))
+        .package(url: "https://github.com/guardian/thrift-swift.git", .exact("0.14.0-gu2"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
This is required to resolve the dependency graph when updating https://github.com/guardian/mobile-apps-thrift-swift to https://github.com/guardian/thrift-swift/releases/tag/v0.14.0-gu1 via https://github.com/guardian/mobile-apps-thrift-swift/pull/1.