### PR TITLE
Use `guardian/french-thrift@0.19.0-gu1`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-ENV THRIFT_VERSION v0.14.0-gu5
+ENV FRENCH_THRIFT_VERSION v0.19.0-gu1
 
 RUN apt-get update
 RUN apt-get install -y git
@@ -23,7 +23,7 @@ RUN buildDeps=" \
 		pkg-config \
 	"; \
 	apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
-	&& curl -k -sSL "https://github.com/guardian/french-thrift/archive/${THRIFT_VERSION}.tar.gz" -o thrift.tar.gz \
+	&& curl -k -sSL "https://github.com/guardian/french-thrift/archive/${FRENCH_THRIFT_VERSION}.tar.gz" -o thrift.tar.gz \
 	&& mkdir -p /usr/src/thrift \
 	&& tar zxf thrift.tar.gz -C /usr/src/thrift --strip-components=1 \
 	&& rm thrift.tar.gz \

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["OphanThrift"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/guardian/thrift-swift.git", .upToNextMinor(from: "0.14.0-gu6"))
+        .package(url: "https://github.com/guardian/thrift-swift.git", .upToNextMinor(from: "0.19.0-gu1"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
## What does this change?

- Compiles models with `guardian/french-thrift@0.19.0-gu1`
- References `guardian/thrift-swift@0.19.0-gu1`

## Release process

- ~Merge to `master` and push a new tag `0.36.0`~ this probably isn't necessary!!

Part of https://github.com/guardian/bridget/issues/127 to get apps Thrift dependencies onto a base of `apache/thrift@0.19`