### PR TITLE
Update to v0.21.0 of guardian/thrift-swift and point to Apache Thrift in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-ENV FRENCH_THRIFT_VERSION v0.19.0-gu1
+ENV THRIFT_VERSION v0.21.0
 
 RUN apt-get update
 RUN apt-get install -y git
@@ -23,7 +23,7 @@ RUN buildDeps=" \
 		pkg-config \
 	"; \
 	apt-get install -y --no-install-recommends $buildDeps && rm -rf /var/lib/apt/lists/* \
-	&& curl -k -sSL "https://github.com/guardian/french-thrift/archive/${FRENCH_THRIFT_VERSION}.tar.gz" -o thrift.tar.gz \
+	&& curl -k -sSL "https://github.com/apache/thrift/archive/${THRIFT_VERSION}.tar.gz" -o thrift.tar.gz \
 	&& mkdir -p /usr/src/thrift \
 	&& tar zxf thrift.tar.gz -C /usr/src/thrift --strip-components=1 \
 	&& rm thrift.tar.gz \

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["OphanThrift"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/guardian/thrift-swift.git", .exact("0.19.0-gu1"))
+        .package(url: "https://github.com/guardian/thrift-swift.git", .exact("0.21.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
## What does this change?

Once https://github.com/guardian/thrift-swift/pull/8 is merged, we can update ophan-thrift-swift to use the latest release of guardian/thrift-swift. This is part of the larger process documented [here](https://theguardian.atlassian.net/browse/LIVE-7287) to decommission French Thrift.

This PR also updates the Dockerfile (used to describe the environment needed to auto-generate the Swift Package) to point to the latest version of Apache Thrift.

We'll need to create a new release once this PR is merged, so that the latest version of Ophan Thrift Swift with these changes can be used in the iOS app. 

## How to test
We'll update the iOS app to use the latest version of this repo when all the related PRs are in the right state, and will then do a smoke test of the app to verify that everything is working as expected.