### PR TITLE
Update to french-thrift v0.21.0-gu2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-ENV FRENCH_THRIFT_VERSION v0.19.0-gu1
+ENV FRENCH_THRIFT_VERSION v0.21.0-gu2
 
 RUN apt-get update
 RUN apt-get install -y git

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["OphanThrift"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/guardian/thrift-swift.git", .exact("0.19.0-gu1"))
+        .package(url: "https://github.com/guardian/thrift-swift.git", .exact("0.21.0-gu2"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
## What does this change?
In https://github.com/guardian/thrift-swift/pull/11, we update guardian/thrift-swift to point to the latest version of french-thrift, and here we update ophan-thrift-swift to use the latest release of guardian/thrift-swift.

This PR also updates the Dockerfile (used to describe the environment needed to auto-generate the Swift Package) to point to the latest version of french-thrift.

We'll need to create a new release once this PR is merged, so that the latest version of Ophan Thrift Swift with these changes can be used in the iOS app.

## How to test
We'll update the iOS app to use the latest version of this repo when all the related PRs are in the right state, and will then do a smoke test of the app to verify that everything is working as expected.