### PR TITLE
chore: Use GitHub app token instead of user PAT

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,14 +1,20 @@
 name: 'Update ophan-thrift-swift'
 description: 'Automatically generates Swift Thrift classes (for Ophan tracking) in the iOS Live App'
 inputs:
-  # Configure a personal access token as a secret (in your repo) and pass it to this action
-  # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#using-encrypted-secrets-in-a-workflow'
-  personal-access-token:
-    description: 'Personal access token used to interact with ophan and ophan-thrift-swift repos'
+  # For example usage, see https://github.com/guardian/ophan/pull/7248
+  app-token:
+    description: 'GitHub App installation token'
+    required: true
+  app-slug:
+    description: 'GitHub App slug'
+    required: true
+  app-user-id:
+    description: 'GitHub App user ID'
     required: true
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - ${{ inputs.personal-access-token }}
-
+    - ${{ inputs.app-token }}
+    - ${{ inputs.app-slug }}
+    - ${{ inputs.app-user-id }}

--- a/credential-helper.sh
+++ b/credential-helper.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-echo username=GuardianAndroid
-echo password=$ACCESS_TOKEN
+echo username="$GITHUB_USER_NAME"
+echo password="$GITHUB_TOKEN"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,13 +1,19 @@
 #!/bin/sh -e
 
+export GITHUB_TOKEN="$1"
+export GITHUB_APP_SLUG="$2"
+export GITHUB_USER_ID="$3"
+
+export GITHUB_USER_NAME="${GITHUB_APP_SLUG}"[bot]
+export GITHUB_USER_EMAIL="${GITHUB_USER_ID}"+"${GITHUB_APP_SLUG}"[bot]@users.noreply.github.com
+
 # Describe dependencies (for debugging Docker)
 git --version
 thrift --version
 
 # Git setup
-export ACCESS_TOKEN=$1
 git config --global credential.helper "/bin/bash /credential-helper.sh"
-git config --global user.email '<>'
+git config --global user.email "$GITHUB_USER_EMAIL"
 
 # Clone repos and obtain Ophan commit sha
 git clone https://github.com/guardian/ophan.git


### PR DESCRIPTION
## What does this change?
This replaces a PAT with a GitHub app token, which has many benefits.
In this case the driving motivation is to remove GitHub user accounts that are being used as pseudo service accounts so that we can enforce Google SSO for all users in the Guardian org.

Will need to synchronise merge with merge of https://github.com/guardian/ophan/pull/7248.

See issue #19 for context.
This resolves #19.

## How to test
Tested with [a successful run of the generate-swift-classes workflow](https://github.com/guardian/ophan/actions/runs/17738341262) in the Ophan repo.
The test generated [this commit](https://github.com/guardian/ophan-thrift-swift/commit/335c45fcc0d5a4e9f022b600f231865751b2e156).
